### PR TITLE
convert ec userdata to string for comparison

### DIFF
--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -38,7 +38,7 @@ OPTIONS = {
 }
 
 -- Uses editorconfig-core-lua's as yet unreleased iterator API
---function ec_iter(p) do
+--function ec_iter(p)
 --  return ec.open(p)
 --end
 
@@ -59,6 +59,9 @@ function ec_set_values(path)
   if path then
     for name, value in ec_iter(path) do
       if OPTIONS[name] then
+        if type(value) == "userdata" then
+          value = tostring(value)
+        end
         OPTIONS[name](value)
       end
     end


### PR DESCRIPTION
I noticed that expantab was always false.
Since the comparison `(value == "space")` in `indent_style` is always false because the value of indent_size is a userdata not a string.