### PR TITLE
Update to editorconfig-core-lua v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ You'll need the Lua wrapper for editorconfig-core installed. This can be done th
 git clone https://github.com/vktec/vis-editorconfig "$HOME/.config/vis/editorconfig"
 ```
 
-Then add `require "editorconfig/editorconfig"` to your `visrc.lua`.
+Then add `require "editorconfig/edconf"` to your `visrc.lua`.

--- a/edconf.lua
+++ b/edconf.lua
@@ -1,5 +1,5 @@
 require "vis"
-ec = require "editorconfig_core"
+ec = require "editorconfig"
 
 -- Simple wrapper
 function vis_set(option, value)
@@ -16,7 +16,7 @@ end
 
 OPTIONS = {
   indent_style = function (value)
-    vis_set("expandtab", (value == ec.T.INDENT_STYLE_SPACE))
+    vis_set("expandtab", (value == ec.INDENT_STYLE_SPACE))
   end,
 
   indent_size = function (value)


### PR DESCRIPTION
The lua module has been renamed to editorconfig in v0.3.0.[1] The
rename could trigger a naming conflict with the `editorconfig.lua`
module in vis. This commit includes a rename of the script to
`edconf.lua` to prevent the naming conflict.

[1]: https://github.com/editorconfig/editorconfig-core-lua/commit/3393dcf59cdc9e86102a56b2cd4b7aca60f45cee