### PR TITLE
Bugfix for call to ec_set_values in FILE_SAVE_POST hook

### DIFF
--- a/editorconfig.lua
+++ b/editorconfig.lua
@@ -73,5 +73,5 @@ vis.events.subscribe(vis.events.FILE_OPEN, function (file)
 end)
 
 vis.events.subscribe(vis.events.FILE_SAVE_POST, function (file, path)
-  ec_set_values(path)
+  ec_set_values(file.path)
 end)


### PR DESCRIPTION
Editorconfig tends to complain that the path should be a full
path. Adjusting the call to the one specified for the FILE_OPEN
hook solves that for me. I'm not sure if this also occurs with
editorconfig-core-lua < 0.3.0, though.